### PR TITLE
Named the dense layer for metadata consistency.

### DIFF
--- a/model/model.ipynb
+++ b/model/model.ipynb
@@ -120,7 +120,7 @@
     "# Build the model, the model we build here is a simple fully connected deep neural network, containing 3 hidden layers and one output layer.\n",
     "\n",
     "model = Sequential()\n",
-    "model.add(Dense(32, activation = 'relu', input_dim = len(X.columns)))\n",
+    "model.add(Dense(32, activation = 'relu', input_dim = len(X.columns), name=\"dense\"))\n",
     "model.add(Dropout(0.2))\n",
     "model.add(Dense(32))\n",
     "model.add(BatchNormalization())\n",


### PR DESCRIPTION
I ran into issues where the model metadata for the input later gets changed for some reason. As a result, the inference client breaks. Explicitly setting the input layer name should solve this. 